### PR TITLE
Fix a couple of minor grammatical issues introduced in my last PR

### DIFF
--- a/src/main/kotlin/me/luligabi/yet_another_industrialization/common/util/YAIText.kt
+++ b/src/main/kotlin/me/luligabi/yet_another_industrialization/common/util/YAIText.kt
@@ -107,7 +107,7 @@ interface YAIText {
     fun machineRemoverTooLarge(): MutableComponent
 
     @WithStyle("machine_remover")
-    @LangKey(text = ["Sorry can't remove this type of machine :("])
+    @LangKey(text = ["Sorry, can't remove this type of machine :("])
     fun machineRemoverBanned(): MutableComponent
 
     @WithStyle("gray")
@@ -190,7 +190,7 @@ interface YAIText {
     @LangKey(text = ["Large Storage Unit Tiers"])
     fun largeStorageUnitTiers(): MutableComponent
 
-    @LangKey(text = ["Capacity: %s%s"])
+    @LangKey(text = ["Capacity: %s%s EU"])
     fun largeStorageUnitTierCapacity(digit: String, unit: String): MutableComponent
 
     @WithStyle("gray")


### PR DESCRIPTION
While looking at the diff to see how styling parameters worked under the new API, I noticed I had actually gotten a few of the lang entries very slightly wrong in my last PR.

This entire PR genuinely just adds a comma and an "EU" back to the lang entries where they belonged. 